### PR TITLE
Revise dependency bounds for PVP compliance.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           - '9.2'
           - '9.4'
           - '9.6'
+          - '9.8'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -107,7 +108,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.6'
+            && matrix.ghc == '9.8'
         run: >
           mv ${{ env.cabal-build-dir }}/build/*/*/*/doc/html/* gh-pages
 
@@ -117,7 +118,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.6'
+            && matrix.ghc == '9.8'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -28,15 +28,15 @@ flag release
   manual: True
 
 common dependency-base
-    build-depends:base                            >= 4.14.3.0   && < 5
+    build-depends:base                            >= 4.14.3.0   && < 4.20
 common dependency-bech32
-    build-depends:bech32                          >= 1.1.4
+    build-depends:bech32                          >= 1.1.4      && < 1.2
 common dependency-hspec
-    build-depends:hspec                           >= 2.11.7
+    build-depends:hspec                           >= 2.11.7     && < 2.12
 common dependency-template-haskell
-    build-depends:template-haskell                >= 2.16.0.0
+    build-depends:template-haskell                >= 2.16.0.0   && < 2.22
 common dependency-text
-    build-depends:text                            >= 1.2.4.1
+    build-depends:text                            >= 1.2.4.1    && < 2.2
 
 library
   import:

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -14,7 +14,9 @@ homepage:           https://github.com/input-output-hk/bech32
 bug-reports:        https://github.com/input-output-hk/bech32/issues
 category:           Web
 build-type:         Simple
-extra-source-files: ChangeLog.md
+
+extra-doc-files:
+  ChangeLog.md
 
 source-repository head
   type:     git

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -28,15 +28,15 @@ flag release
   manual: True
 
 common dependency-base
-    build-depends:base                            >= 4.11.1.0   && < 5
+    build-depends:base                            >= 4.14.3.0   && < 5
 common dependency-bech32
-    build-depends:bech32                          >= 1.1.2
+    build-depends:bech32                          >= 1.1.4
 common dependency-hspec
-    build-depends:hspec
+    build-depends:hspec                           >= 2.11.7
 common dependency-template-haskell
-    build-depends:template-haskell
+    build-depends:template-haskell                >= 2.16.0.0
 common dependency-text
-    build-depends:text
+    build-depends:text                            >= 1.2.4.1
 
 library
   import:

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -27,7 +27,23 @@ flag release
   default: False
   manual: True
 
+common dependency-base
+    build-depends:base                            >= 4.11.1.0   && < 5
+common dependency-bech32
+    build-depends:bech32                          >= 1.1.2
+common dependency-hspec
+    build-depends:hspec
+common dependency-template-haskell
+    build-depends:template-haskell
+common dependency-text
+    build-depends:text
+
 library
+  import:
+    , dependency-base
+    , dependency-bech32
+    , dependency-template-haskell
+    , dependency-text
   default-language:
       Haskell2010
   default-extensions:
@@ -37,17 +53,21 @@ library
       -Wall -Wcompat -fwarn-redundant-constraints
   if flag(release)
     ghc-options: -Werror
-  build-depends:
-    , base >= 4.11.1.0 && < 5
-    , bech32 >= 1.1.2
-    , template-haskell
-    , text
   hs-source-dirs:
       src
   exposed-modules:
       Codec.Binary.Bech32.TH
 
 test-suite bech32-th-test
+  import:
+    , dependency-base
+    , dependency-bech32
+    , dependency-hspec
+    , dependency-template-haskell
+  build-depends:
+    , bech32-th
+  build-tool-depends:
+    , hspec-discover:hspec-discover
   default-language:
       Haskell2010
   default-extensions:
@@ -62,14 +82,6 @@ test-suite bech32-th-test
       -threaded -rtsopts -with-rtsopts=-N
   if flag(release)
     ghc-options: -Werror
-  build-depends:
-    , base
-    , bech32
-    , bech32-th
-    , hspec
-    , template-haskell
-  build-tool-depends:
-    , hspec-discover:hspec-discover
   main-is:
       Main.hs
   other-modules:

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -1,3 +1,4 @@
+cabal-version:      3.0
 name:               bech32-th
 version:            1.1.1
 synopsis:           Template Haskell extensions to the Bech32 library.
@@ -14,7 +15,6 @@ bug-reports:        https://github.com/input-output-hk/bech32/issues
 category:           Web
 build-type:         Simple
 extra-source-files: ChangeLog.md
-cabal-version:      >=1.10
 
 source-repository head
   type:     git
@@ -66,8 +66,8 @@ test-suite bech32-th-test
     , bech32-th
     , hspec
     , template-haskell
-  build-tools:
-      hspec-discover
+  build-tool-depends:
+      hspec-discover:hspec-discover
   main-is:
       Main.hs
   other-modules:

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -38,7 +38,7 @@ library
   if flag(release)
     ghc-options: -Werror
   build-depends:
-      base >= 4.11.1.0 && < 5
+    , base >= 4.11.1.0 && < 5
     , bech32 >= 1.1.2
     , template-haskell
     , text
@@ -63,13 +63,13 @@ test-suite bech32-th-test
   if flag(release)
     ghc-options: -Werror
   build-depends:
-      base
+    , base
     , bech32
     , bech32-th
     , hspec
     , template-haskell
   build-tool-depends:
-      hspec-discover:hspec-discover
+    , hspec-discover:hspec-discover
   main-is:
       Main.hs
   other-modules:

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -32,37 +32,37 @@ flag static
   manual: True
 
 common dependency-array
-    build-depends:array
+    build-depends:array                           >= 0.5.4.0
 common dependency-base
-    build-depends:base                            >= 4.11.1.0   && < 5
+    build-depends:base                            >= 4.14.3.0   && < 5
 common dependency-base58-bytestring
-    build-depends:base58-bytestring
+    build-depends:base58-bytestring               >= 0.1.0
 common dependency-bytestring
-    build-depends:bytestring
+    build-depends:bytestring                      >= 0.10.12.0
 common dependency-containers
-    build-depends:containers
+    build-depends:containers                      >= 0.6.5.1
 common dependency-deepseq
-    build-depends:deepseq
+    build-depends:deepseq                         >= 1.4.4.0
 common dependency-extra
-    build-depends:extra
+    build-depends:extra                           >= 1.7.14
 common dependency-hspec
-    build-depends:hspec
+    build-depends:hspec                           >= 2.11.7
 common dependency-memory
-    build-depends:memory
+    build-depends:memory                          >= 0.18.0
 common dependency-optparse-applicative
-    build-depends:optparse-applicative
+    build-depends:optparse-applicative            >= 0.18.1.0
 common dependency-prettyprinter
-    build-depends:prettyprinter
+    build-depends:prettyprinter                   >= 1.7.1
 common dependency-prettyprinter-ansi-terminal
-    build-depends:prettyprinter-ansi-terminal
+    build-depends:prettyprinter-ansi-terminal     >= 1.1.3
 common dependency-process
-    build-depends:process
+    build-depends:process                         >= 1.6.13.2
 common dependency-QuickCheck
-    build-depends:QuickCheck                      >= 2.12
+    build-depends:QuickCheck                      >= 2.14.3
 common dependency-text
-    build-depends:text
+    build-depends:text                            >= 1.2.4.1
 common dependency-vector
-    build-depends:vector
+    build-depends:vector                          >= 0.13.1.0
 
 library
   import:

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -1,3 +1,4 @@
+cabal-version: 3.0
 name:          bech32
 version:       1.1.4
 synopsis:      Implementation of the Bech32 cryptocurrency address format (BIP 0173).
@@ -13,7 +14,6 @@ bug-reports:   https://github.com/input-output-hk/bech32/issues
 category:      Web
 build-type:    Simple
 extra-source-files:  ChangeLog.md
-cabal-version: >=1.10
 
 source-repository head
   type:     git
@@ -106,9 +106,9 @@ test-suite bech32-test
     , QuickCheck >= 2.12
     , text
     , vector
-  build-tools:
-      hspec-discover
-    , bech32
+  build-tool-depends:
+      hspec-discover:hspec-discover
+    , bech32:bech32
   main-is:
       Main.hs
   other-modules:

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -58,6 +58,8 @@ executable bech32
   main-is: Main.hs
   other-modules:
       Paths_bech32
+  autogen-modules:
+      Paths_bech32
   hs-source-dirs:
       app
   build-depends:

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -32,37 +32,37 @@ flag static
   manual: True
 
 common dependency-array
-    build-depends:array                           >= 0.5.4.0
+    build-depends:array                           >= 0.5.4.0    && < 0.6
 common dependency-base
-    build-depends:base                            >= 4.14.3.0   && < 5
+    build-depends:base                            >= 4.14.3.0   && < 4.20
 common dependency-base58-bytestring
-    build-depends:base58-bytestring               >= 0.1.0
+    build-depends:base58-bytestring               >= 0.1.0      && < 0.2
 common dependency-bytestring
-    build-depends:bytestring                      >= 0.10.12.0
+    build-depends:bytestring                      >= 0.10.12.0  && < 0.13
 common dependency-containers
-    build-depends:containers                      >= 0.6.5.1
+    build-depends:containers                      >= 0.6.5.1    && < 0.7
 common dependency-deepseq
-    build-depends:deepseq                         >= 1.4.4.0
+    build-depends:deepseq                         >= 1.4.4.0    && < 1.6
 common dependency-extra
-    build-depends:extra                           >= 1.7.14
+    build-depends:extra                           >= 1.7.14     && < 1.8
 common dependency-hspec
-    build-depends:hspec                           >= 2.11.7
+    build-depends:hspec                           >= 2.11.7     && < 2.12
 common dependency-memory
-    build-depends:memory                          >= 0.18.0
+    build-depends:memory                          >= 0.18.0     && < 0.19
 common dependency-optparse-applicative
-    build-depends:optparse-applicative            >= 0.18.1.0
+    build-depends:optparse-applicative            >= 0.18.1.0   && < 0.19
 common dependency-prettyprinter
-    build-depends:prettyprinter                   >= 1.7.1
+    build-depends:prettyprinter                   >= 1.7.1      && < 1.8
 common dependency-prettyprinter-ansi-terminal
-    build-depends:prettyprinter-ansi-terminal     >= 1.1.3
+    build-depends:prettyprinter-ansi-terminal     >= 1.1.3      && < 1.2
 common dependency-process
-    build-depends:process                         >= 1.6.13.2
+    build-depends:process                         >= 1.6.13.2   && < 1.7
 common dependency-QuickCheck
-    build-depends:QuickCheck                      >= 2.14.3
+    build-depends:QuickCheck                      >= 2.14.3     && < 2.15
 common dependency-text
-    build-depends:text                            >= 1.2.4.1
+    build-depends:text                            >= 1.2.4.1    && < 2.2
 common dependency-vector
-    build-depends:vector                          >= 0.13.1.0
+    build-depends:vector                          >= 0.13.1.0   && < 0.14
 
 library
   import:

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -13,7 +13,9 @@ homepage:      https://github.com/input-output-hk/bech32
 bug-reports:   https://github.com/input-output-hk/bech32/issues
 category:      Web
 build-type:    Simple
-extra-source-files:  ChangeLog.md
+
+extra-doc-files:
+  ChangeLog.md
 
 source-repository head
   type:     git

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -31,7 +31,47 @@ flag static
   default: False
   manual: True
 
+common dependency-array
+    build-depends:array
+common dependency-base
+    build-depends:base                            >= 4.11.1.0   && < 5
+common dependency-base58-bytestring
+    build-depends:base58-bytestring
+common dependency-bytestring
+    build-depends:bytestring
+common dependency-containers
+    build-depends:containers
+common dependency-deepseq
+    build-depends:deepseq
+common dependency-extra
+    build-depends:extra
+common dependency-hspec
+    build-depends:hspec
+common dependency-memory
+    build-depends:memory
+common dependency-optparse-applicative
+    build-depends:optparse-applicative
+common dependency-prettyprinter
+    build-depends:prettyprinter
+common dependency-prettyprinter-ansi-terminal
+    build-depends:prettyprinter-ansi-terminal
+common dependency-process
+    build-depends:process
+common dependency-QuickCheck
+    build-depends:QuickCheck                      >= 2.12
+common dependency-text
+    build-depends:text
+common dependency-vector
+    build-depends:vector
+
 library
+  import:
+    , dependency-array
+    , dependency-base
+    , dependency-bytestring
+    , dependency-containers
+    , dependency-extra
+    , dependency-text
   default-language:
       Haskell2010
   default-extensions:
@@ -41,13 +81,6 @@ library
       -Wall -Wcompat -fwarn-redundant-constraints
   if flag(release)
     ghc-options: -Werror
-  build-depends:
-    , array
-    , base >= 4.11.1.0 && <5
-    , bytestring
-    , containers
-    , extra
-    , text
   hs-source-dirs:
       src
   exposed-modules:
@@ -55,6 +88,18 @@ library
       Codec.Binary.Bech32.Internal
 
 executable bech32
+  import:
+    , dependency-base
+    , dependency-base58-bytestring
+    , dependency-bytestring
+    , dependency-extra
+    , dependency-memory
+    , dependency-optparse-applicative
+    , dependency-prettyprinter
+    , dependency-prettyprinter-ansi-terminal
+    , dependency-text
+  build-depends:
+    , bech32
   main-is: Main.hs
   other-modules:
       Paths_bech32
@@ -62,17 +107,6 @@ executable bech32
       Paths_bech32
   hs-source-dirs:
       app
-  build-depends:
-    , base
-    , base58-bytestring
-    , bech32
-    , bytestring
-    , extra
-    , memory
-    , optparse-applicative
-    , prettyprinter
-    , prettyprinter-ansi-terminal
-    , text
   ghc-options:
       -Wall -Wcompat -fwarn-redundant-constraints
       -threaded -rtsopts -with-rtsopts=-N
@@ -85,6 +119,24 @@ executable bech32
   default-language: Haskell2010
 
 test-suite bech32-test
+  import:
+    , dependency-base
+    , dependency-base58-bytestring
+    , dependency-bytestring
+    , dependency-containers
+    , dependency-deepseq
+    , dependency-extra
+    , dependency-hspec
+    , dependency-memory
+    , dependency-process
+    , dependency-QuickCheck
+    , dependency-text
+    , dependency-vector
+  build-depends:
+    , bech32
+  build-tool-depends:
+    , bech32:bech32
+    , hspec-discover:hspec-discover
   default-language:
       Haskell2010
   type:
@@ -96,23 +148,6 @@ test-suite bech32-test
       -threaded -rtsopts -with-rtsopts=-N
   if flag(release)
     ghc-options: -Werror
-  build-depends:
-    , base
-    , base58-bytestring
-    , bech32
-    , bytestring
-    , containers
-    , deepseq
-    , extra
-    , hspec
-    , memory
-    , process
-    , QuickCheck >= 2.12
-    , text
-    , vector
-  build-tool-depends:
-    , bech32:bech32
-    , hspec-discover:hspec-discover
   main-is:
       Main.hs
   other-modules:

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -42,7 +42,7 @@ library
   if flag(release)
     ghc-options: -Werror
   build-depends:
-      array
+    , array
     , base >= 4.11.1.0 && <5
     , bytestring
     , containers
@@ -63,7 +63,7 @@ executable bech32
   hs-source-dirs:
       app
   build-depends:
-      base
+    , base
     , base58-bytestring
     , bech32
     , bytestring
@@ -97,7 +97,7 @@ test-suite bech32-test
   if flag(release)
     ghc-options: -Werror
   build-depends:
-      base
+    , base
     , base58-bytestring
     , bech32
     , bytestring
@@ -111,8 +111,8 @@ test-suite bech32-test
     , text
     , vector
   build-tool-depends:
-      hspec-discover:hspec-discover
     , bech32:bech32
+    , hspec-discover:hspec-discover
   main-is:
       Main.hs
   other-modules:

--- a/cabal.project
+++ b/cabal.project
@@ -1,6 +1,3 @@
-index-state:
-  , hackage.haskell.org 2023-07-27T22:41:49Z
-
 packages:
   bech32/bech32.cabal
   bech32-th/bech32-th.cabal

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,5 @@
 packages:
-  bech32/bech32.cabal
-  bech32-th/bech32-th.cabal
+  bech32
+  bech32-th
 
 flags: +development


### PR DESCRIPTION
This PR revises the bounds of package dependencies for compliance with the [Haskell PVP Specification](https://pvp.haskell.org/).

Additionally, this PR adds CI support for GHC 9.8.

### Related Issue

https://cardanofoundation.atlassian.net/browse/ADP-3295