### PR TITLE
Prepare for release of version `1.1.5`.

### DIFF
--- a/bech32-th/ChangeLog.md
+++ b/bech32-th/ChangeLog.md
@@ -1,5 +1,15 @@
 # ChangeLog for `bech32-th`
 
+## [1.1.5] - 2024-02-23
+
+### Fixed
+
+- Specified version bounds for all package dependencies.
+
+### Added
+
+- Added support for GHC 9.8 series.
+
 ## 1.1.1 -- 2021-06-11
 
 + Upgraded CI to build with Cabal 3.4.0.0 and GHC 8.10.4.

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               bech32-th
-version:            1.1.1
+version:            1.1.5
 synopsis:           Template Haskell extensions to the Bech32 library.
 description:        Template Haskell extensions to the Bech32 library, including
                     quasi-quoters for compile-time checking of Bech32 string
@@ -30,7 +30,7 @@ flag release
 common dependency-base
     build-depends:base                            >= 4.14.3.0   && < 4.20
 common dependency-bech32
-    build-depends:bech32                          >= 1.1.4      && < 1.2
+    build-depends:bech32                          >= 1.1.5      && < 1.2
 common dependency-hspec
     build-depends:hspec                           >= 2.11.7     && < 2.12
 common dependency-template-haskell

--- a/bech32/ChangeLog.md
+++ b/bech32/ChangeLog.md
@@ -1,6 +1,17 @@
 # Changelog
 
 <!-- This ChangeLog follows a format specified by: https://keepachangelog.com/en/1.0.0/ -->
+
+## [1.1.5] - 2024-02-23
+
+### Fixed
+
+- Specified version bounds for all package dependencies.
+
+### Added
+
+- Added support for GHC 9.8 series.
+
 ## [1.1.4] - 2023-07-28
 
 ### Fixed

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          bech32
-version:       1.1.4
+version:       1.1.5
 synopsis:      Implementation of the Bech32 cryptocurrency address format (BIP 0173).
 description:   Implementation of the Bech32 cryptocurrency address format documented in the
                BIP (Bitcoin Improvement Proposal) 0173.


### PR DESCRIPTION
This PR prepares for the releases of the following packages on Hackage:

- Version `1.1.5` of `bech32`
- Version `1.1.5` of `bech32-th`

### Next Steps

After this PR is merged to `master`, we will need to perform the following steps:
1. Apply the tag `v1.1.5` to the merge commit.
2. Upload version `1.1.5` of `bech32` to Hackage.
3. Upload version `1.1.5` of `bech32-th` to Hackage.
4. Based on the `v1.1.5` tag, create a GitHub release that links to both Hackage releases.

### Related Issues

https://cardanofoundation.atlassian.net/browse/ADP-3295
https://cardanofoundation.atlassian.net/browse/ADP-3296