### PR TITLE
Revise upper version bounds for dependencies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
           - macOS-latest
           - windows-latest
         cabal:
-          - 3.10.2.0
+          - '3.10'
         ghc:
           - '8.10'
           - '9.0'

--- a/bech32-th/ChangeLog.md
+++ b/bech32-th/ChangeLog.md
@@ -1,5 +1,11 @@
 # ChangeLog for `bech32-th`
 
+## [1.1.6] - 2024-04-24
+
+### Changed
+
+- Revised upper version bounds for dependencies.
+
 ## [1.1.5] - 2024-02-23
 
 ### Fixed

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -6,7 +6,7 @@ description:        Template Haskell extensions to the Bech32 library, including
                     quasi-quoters for compile-time checking of Bech32 string
                     literals.
 author:             IOHK Engineering Team
-maintainer:         operations@iohk.io, erikd@mega-nerd.com, jonathan.knowles@iohk.io
+maintainer:         operations@iohk.io, erikd@mega-nerd.com, mail@jonathanknowles.net
 copyright:          2020-2023 IOHK
 license:            Apache-2.0
 license-file:       LICENSE

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               bech32-th
-version:            1.1.5
+version:            1.1.6
 synopsis:           Template Haskell extensions to the Bech32 library.
 description:        Template Haskell extensions to the Bech32 library, including
                     quasi-quoters for compile-time checking of Bech32 string

--- a/bech32/ChangeLog.md
+++ b/bech32/ChangeLog.md
@@ -2,6 +2,12 @@
 
 <!-- This ChangeLog follows a format specified by: https://keepachangelog.com/en/1.0.0/ -->
 
+## [1.1.6] - 2024-04-24
+
+### Changed
+
+- Revised upper version bounds for dependencies.
+
 ## [1.1.5] - 2024-02-23
 
 ### Fixed

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -5,7 +5,7 @@ synopsis:      Implementation of the Bech32 cryptocurrency address format (BIP 0
 description:   Implementation of the Bech32 cryptocurrency address format documented in the
                BIP (Bitcoin Improvement Proposal) 0173.
 author:        IOHK Engineering Team
-maintainer:    operations@iohk.io, erikd@mega-nerd.com, jonathan.knowles@iohk.io
+maintainer:    operations@iohk.io, erikd@mega-nerd.com, mail@jonathanknowles.net
 copyright:     2017 Marko Bencun, 2019-2023 IOHK
 license:       Apache-2.0
 license-file:  LICENSE

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -58,7 +58,7 @@ common dependency-prettyprinter-ansi-terminal
 common dependency-process
     build-depends:process                         >= 1.6.13.2   && < 1.7
 common dependency-QuickCheck
-    build-depends:QuickCheck                      >= 2.14.3     && < 2.15
+    build-depends:QuickCheck                      >= 2.14.3     && < 2.16
 common dependency-text
     build-depends:text                            >= 1.2.4.1    && < 2.2
 common dependency-vector

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          bech32
-version:       1.1.5
+version:       1.1.6
 synopsis:      Implementation of the Bech32 cryptocurrency address format (BIP 0173).
 description:   Implementation of the Bech32 cryptocurrency address format documented in the
                BIP (Bitcoin Improvement Proposal) 0173.

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -40,7 +40,7 @@ common dependency-base58-bytestring
 common dependency-bytestring
     build-depends:bytestring                      >= 0.10.12.0  && < 0.13
 common dependency-containers
-    build-depends:containers                      >= 0.6.5.1    && < 0.7
+    build-depends:containers                      >= 0.6.5.1    && < 0.8
 common dependency-deepseq
     build-depends:deepseq                         >= 1.4.4.0    && < 1.6
 common dependency-extra


### PR DESCRIPTION
This PR revises the following upper version bounds for dependencies:

```patch
- containers < 0.7
+ containers < 0.8
- QuickCheck < 2.15
+ QuickCheck < 2.16
```

I have manually confirmed that building succeeds with the following constraints:
- `containers == 0.7`
- `QuickCheck == 2.15`

Fixes #70.