### PR TITLE
Temporarily exclude `macOS` with GHC versions `{8.10,9.0}` from CI build matrix.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,13 @@ jobs:
           - '9.4'
           - '9.6'
           - '9.8'
+        exclude:
+          # TODO: https://github.com/IntersectMBO/bech32/issues/72
+          # To work around the above issue, we exclude the following versions:
+          - os: macOS-latest
+            ghc: '8.10'
+          - os: macOS-latest
+            ghc: '9.0'
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR is a temporary workaround for the following issue:

- https://github.com/IntersectMBO/bech32/issues/72