### PR TITLE
Support GHC 9.12.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
           - '9.6'
           - '9.8'
           - '9.10'
+          - '9.12'
         exclude:
           # TODO: https://github.com/IntersectMBO/bech32/issues/72
           # To work around the above issue, we exclude the following versions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.10'
+            && matrix.ghc == '9.12'
         run: >
           mv ${{ env.cabal-build-dir }}/build/*/*/*/doc/html/* gh-pages
 
@@ -127,7 +127,7 @@ jobs:
         if: |
             github.ref == 'refs/heads/main'
             && matrix.os == 'ubuntu-latest'
-            && matrix.ghc == '9.10'
+            && matrix.ghc == '9.12'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           branch: gh-pages

--- a/bech32-th/ChangeLog.md
+++ b/bech32-th/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for `bech32-th`
 
+## [1.1.8] - 2024-12-27
+
+- Added support for GHC 9.12 series.
+
 ## [1.1.7] - 2024-05-20
 
 - Added support for GHC 9.10 series.

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -34,7 +34,7 @@ common dependency-bech32
 common dependency-hspec
     build-depends:hspec                           >= 2.11.7     && < 2.12
 common dependency-template-haskell
-    build-depends:template-haskell                >= 2.16.0.0   && < 2.23
+    build-depends:template-haskell                >= 2.16.0.0   && < 2.24
 common dependency-text
     build-depends:text                            >= 1.2.4.1    && < 2.2
 

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -28,7 +28,7 @@ flag release
   manual: True
 
 common dependency-base
-    build-depends:base                            >= 4.14.3.0   && < 4.21
+    build-depends:base                            >= 4.14.3.0   && < 4.22
 common dependency-bech32
     build-depends:bech32                          >= 1.1.7      && < 1.2
 common dependency-hspec

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               bech32-th
-version:            1.1.7
+version:            1.1.8
 synopsis:           Template Haskell extensions to the Bech32 library.
 description:        Template Haskell extensions to the Bech32 library, including
                     quasi-quoters for compile-time checking of Bech32 string

--- a/bech32/ChangeLog.md
+++ b/bech32/ChangeLog.md
@@ -2,6 +2,10 @@
 
 <!-- This ChangeLog follows a format specified by: https://keepachangelog.com/en/1.0.0/ -->
 
+## [1.1.8] - 2024-12-27
+
+- Added support for GHC 9.12 series.
+
 ## [1.1.7] - 2024-05-20
 
 - Added support for GHC 9.10 series.

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -34,7 +34,7 @@ flag static
 common dependency-array
     build-depends:array                           >= 0.5.4.0    && < 0.6
 common dependency-base
-    build-depends:base                            >= 4.14.3.0   && < 4.21
+    build-depends:base                            >= 4.14.3.0   && < 4.22
 common dependency-base58-bytestring
     build-depends:base58-bytestring               >= 0.1.0      && < 0.2
 common dependency-bytestring

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          bech32
-version:       1.1.7
+version:       1.1.8
 synopsis:      Implementation of the Bech32 cryptocurrency address format (BIP 0173).
 description:   Implementation of the Bech32 cryptocurrency address format documented in the
                BIP (Bitcoin Improvement Proposal) 0173.

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -44,7 +44,7 @@ common dependency-containers
 common dependency-deepseq
     build-depends:deepseq                         >= 1.4.4.0    && < 1.6
 common dependency-extra
-    build-depends:extra                           >= 1.7.14     && < 1.8
+    build-depends:extra                           >= 1.7.14     && < 1.9
 common dependency-hspec
     build-depends:hspec                           >= 2.11.7     && < 2.12
 common dependency-memory


### PR DESCRIPTION
This PR:
- adds GHC 9.12 to the CI build matrix.
- bumps upper version bounds of the following dependencies:
    - `base`
    - `extra`
    - `template-haskell`
- bumps the minor version of both `bech32` and `bech32-th`.

I'd be happy to release these updates to Hackage (I'm a maintainer for both `bech32` and `bech32-th` packages).

Thanks!