### PR TITLE
Prepare for new release (`1.1.9`).

### DIFF
--- a/bech32-th/ChangeLog.md
+++ b/bech32-th/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for `bech32-th`
 
+## [1.1.9] - 2025-06-05
+
+- Revised upper version bounds for dependencies.
+
 ## [1.1.8] - 2024-12-27
 
 - Added support for GHC 9.12 series.

--- a/bech32-th/bech32-th.cabal
+++ b/bech32-th/bech32-th.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               bech32-th
-version:            1.1.8
+version:            1.1.9
 synopsis:           Template Haskell extensions to the Bech32 library.
 description:        Template Haskell extensions to the Bech32 library, including
                     quasi-quoters for compile-time checking of Bech32 string

--- a/bech32/ChangeLog.md
+++ b/bech32/ChangeLog.md
@@ -2,6 +2,10 @@
 
 <!-- This ChangeLog follows a format specified by: https://keepachangelog.com/en/1.0.0/ -->
 
+## [1.1.9] - 2025-06-05
+
+- Revised upper version bounds for dependencies.
+
 ## [1.1.8] - 2024-12-27
 
 - Added support for GHC 9.12 series.

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -40,7 +40,7 @@ common dependency-base58-bytestring
 common dependency-bytestring
     build-depends:bytestring                      >= 0.10.12.0  && < 0.13
 common dependency-containers
-    build-depends:containers                      >= 0.6.5.1    && < 0.8
+    build-depends:containers                      >= 0.6.5.1    && < 0.9
 common dependency-deepseq
     build-depends:deepseq                         >= 1.4.4.0    && < 1.6
 common dependency-extra

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name:          bech32
-version:       1.1.8
+version:       1.1.9
 synopsis:      Implementation of the Bech32 cryptocurrency address format (BIP 0173).
 description:   Implementation of the Bech32 cryptocurrency address format documented in the
                BIP (Bitcoin Improvement Proposal) 0173.

--- a/bech32/bech32.cabal
+++ b/bech32/bech32.cabal
@@ -50,7 +50,7 @@ common dependency-hspec
 common dependency-memory
     build-depends:memory                          >= 0.18.0     && < 0.19
 common dependency-optparse-applicative
-    build-depends:optparse-applicative            >= 0.18.1.0   && < 0.19
+    build-depends:optparse-applicative            >= 0.18.1.0   && < 0.20
 common dependency-prettyprinter
     build-depends:prettyprinter                   >= 1.7.1      && < 1.8
 common dependency-prettyprinter-ansi-terminal


### PR DESCRIPTION
Related Issue:

https://github.com/commercialhaskell/stackage/issues/7766

This PR:
- bumps the upper version bound for `containers`
  (allowing version [`0.8`](http://hackage.haskell.org/package/containers-0.8/))
- bumps the upper version bound for `optparse-applicative`
  (allowing version [`0.19.0.0`](https://hackage.haskell.org/package/optparse-applicative-0.19.0.0))
- bumps the package version of both `bech32` and `bech32-th` to `1.1.9`, in preparation for a new release.